### PR TITLE
[dsch] fix for TypeScript

### DIFF
--- a/TypeScript/ICreateLogger.ts
+++ b/TypeScript/ICreateLogger.ts
@@ -1,0 +1,3 @@
+export interface ICreateLogger {
+  (filename: string): Console;
+}

--- a/TypeScript/IFile.ts
+++ b/TypeScript/IFile.ts
@@ -1,0 +1,6 @@
+
+export interface IFile {
+  found: boolean;
+  ext: string;
+  stream: NodeJS.ReadableStream;
+}

--- a/TypeScript/IServeStatic.ts
+++ b/TypeScript/IServeStatic.ts
@@ -1,0 +1,5 @@
+import { IStorage } from "./IStorage";
+
+export interface IServeStatic {
+  (storage: IStorage, logger: Console, port: number): void;
+}

--- a/TypeScript/IStorage.ts
+++ b/TypeScript/IStorage.ts
@@ -1,0 +1,5 @@
+import { IFile } from "./IFile";
+
+export interface IStorage {
+  prepare(filename: string): Promise<IFile>;
+}

--- a/TypeScript/logger-alt.d.ts
+++ b/TypeScript/logger-alt.d.ts
@@ -1,2 +1,4 @@
+import { ICreateLogger } from "./ICreateLogger";
+
 export declare const createLogger: ICreateLogger;
 

--- a/TypeScript/logger-alt.js
+++ b/TypeScript/logger-alt.js
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { Console } = require('node:console');
 
+/** @type {(filename: string) => Console} */
 const createLogger = (filename) => {
   const filePath = path.join(process.cwd(), filename);
   const fileStream = fs.createWriteStream(filePath);

--- a/TypeScript/logger.d.ts
+++ b/TypeScript/logger.d.ts
@@ -1,5 +1,3 @@
-export interface ICreateLogger {
-  (filename: string): Console;
-}
+import { ICreateLogger } from "./ICreateLogger";
 
 export const createLogger: ICreateLogger;

--- a/TypeScript/logger.js
+++ b/TypeScript/logger.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const { Console } = require('node:console');
 const { PassThrough } = require('node:stream');
 
+/** @type {(filename: string) => Console} */
 const createLogger = (filename) => {
   const filePath = path.join(process.cwd(), filename);
   const fileStream = fs.createWriteStream(filePath);

--- a/TypeScript/server.d.ts
+++ b/TypeScript/server.d.ts
@@ -1,5 +1,3 @@
-export interface IServeStatic {
-  (storage: IStorage, logger: Console, port: number);
-}
+import { IServeStatic } from "./IServeStatic";
 
 export const serveStatic: IServeStatic;

--- a/TypeScript/storage.d.ts
+++ b/TypeScript/storage.d.ts
@@ -1,15 +1,7 @@
-export interface IFile {
-  found: boolean;
-  ext: string;
-  stream: NodeJS.ReadableStream;
-}
-
-export interface IStorage {
-  constructor(folder: string);
-  prepare(filename: string): Promise<IFile>;
-}
+import { IFile } from "./IFile";
+import { IStorage } from "./IStorage";
 
 export class Storage implements IStorage {
   constructor(folder: string);
-  prepare(filename): Promise<IFile>;
+  prepare(filename: string): Promise<IFile>;
 }

--- a/TypeScript/storage.js
+++ b/TypeScript/storage.js
@@ -8,10 +8,12 @@ const toBool = [() => true, () => false];
 class Storage {
   #folder = '';
 
+  /** @param {string} folder */
   constructor(folder) {
     this.#folder = path.join(process.cwd(), folder);
   }
 
+  /** @type {function(string): Promise<import('./IFile').IFile>} */
   async prepare(filename) {
     const paths = [this.#folder, filename];
     if (filename.endsWith('/')) paths.push('index.html');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "strict": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
     "noEmit": true,
     "allowJs": true,
     "checkJs": true,
@@ -14,11 +16,6 @@
     "allowSyntheticDefaultImports": true,
     "pretty": true
   },
-  "include": [
-    "JavaScript/*.js",
-    "JavaScript/*.ts",
-    "TypeScript/*.js",
-    "TypeScript/*.ts"
-  ],
-  "exclude": ["node_modules"]
+  "include": ["TypeScript/**/*.js"],
+  "exclude": ["node_modules", "dist", "./*.config.js", "JavaScript/**/*.js"]
 }


### PR DESCRIPTION
The main problem with the initial TypeScript example is that the interfaces are located in the implementation’s `.d.ts` files, which are part of the implementation.

Interfaces should be declared on the "client" side. This could be a separate module containing the definitions, or it could be an interface declaration directly in the client module (if you don’t need to import it into the implementation, though that is also possible).

An important point is that the interface definition MUST NOT include the constructor, as it limits the implementation details.

So, the definition of `IStorage` must looks like the following:

```diff
export interface IStorage {
-  constructor(folder: string);
  prepare(filename: string): Promise<IFile>;
}
```

And finally the `req.url` has a type `string | undefined`, so the additional check has been added to the `serveStatic`